### PR TITLE
Hotfix: Remove unecessary reduce steps in link

### DIFF
--- a/src/main/scala/org/zouzias/spark/lucenerdd/LuceneRDD.scala
+++ b/src/main/scala/org/zouzias/spark/lucenerdd/LuceneRDD.scala
@@ -159,11 +159,7 @@ class LuceneRDD[T: ClassTag](protected val partitionsRDD: RDD[AbstractLuceneRDDP
 
     val resultsByPart: RDD[(Long, TopK[SparkScoreDoc])] = partitionsRDD.flatMap {
       case partition => queriesB.value.zipWithIndex.map { case (qr, index) =>
-        val results = partition.query(qr, topK)
-          .map(x => monoid.build(x))
-
-        (index.toLong, results.reduceOption(monoid.plus)
-          .getOrElse(monoid.zero))
+        (index.toLong, monoid.build(partition.query(qr, topK)))
       }
     }
 

--- a/src/main/scala/org/zouzias/spark/lucenerdd/spatial/shape/ShapeLuceneRDD.scala
+++ b/src/main/scala/org/zouzias/spark/lucenerdd/spatial/shape/ShapeLuceneRDD.scala
@@ -101,11 +101,7 @@ class ShapeLuceneRDD[K: ClassTag, V: ClassTag]
     logDebug("Compute topK linkage per partition")
     val resultsByPart: RDD[(Long, TopK[SparkScoreDoc])] = partitionsRDD.flatMap {
       case partition => queriesB.value.zipWithIndex.map { case (queryPoint, index) =>
-        val results = mapper(queryPoint, partition).map(x => topKMonoid.build(x))
-          .reduceOption(topKMonoid.plus)
-          .getOrElse(topKMonoid.zero)
-
-        (index.toLong, results)
+        (index.toLong, topKMonoid.build(mapper(queryPoint, partition)))
       }
     }
 


### PR DESCRIPTION
Link methods contain reduce of topK monoids that are not necessary.