### PR TITLE
Introduce blocking on record linkage

### DIFF
--- a/src/main/scala/org/zouzias/spark/lucenerdd/LuceneRDD.scala
+++ b/src/main/scala/org/zouzias/spark/lucenerdd/LuceneRDD.scala
@@ -25,6 +25,7 @@ import org.apache.spark.rdd.RDD
 import org.apache.lucene.search.Query
 import org.apache.spark._
 import org.apache.spark.sql.{DataFrame, Row}
+import org.apache.spark.sql.functions._
 import org.apache.spark.storage.StorageLevel
 import org.zouzias.spark.lucenerdd.analyzers.AnalyzerConfigurable
 import org.zouzias.spark.lucenerdd.models.indexstats.IndexStatistics
@@ -464,51 +465,58 @@ object LuceneRDD extends Versionable
   }
 
   /**
-    * Entity linkage between two [[DataFrame]] by filtering on one or more columns.
+    * Entity linkage between two [[DataFrame]] by blocking / filtering
+    * on one or more columns.
     *
-    * @param queries
-    * @param corpus
-    * @param rowToQueryString
-    * @param queriesPartColumns
-    * @param corpusPartColumns
-    * @param topK
-    * @param indexAnalyzer
-    * @param queryAnalyzer
-    * @param similarity
-    * @tparam T
-    * @return
+    * @param queries Queries / entities to be linked with @corpus
+    * @param entities DataFrame of entities to be linked with queries parameter
+    * @param rowToQueryString Converts each [[Row]] to a 'Lucene Query Syntax'
+    * @param queryPartColumns List of query columns for [[HashPartitioner]]
+    * @param entityPartColumns List of entity columns for [[HashPartitioner]]
+    * @param topK Number of linked results
+    * @param indexAnalyzer Lucene analyzer at index time
+    * @param queryAnalyzer Lucene analyzer at query time
+    * @param similarity Lucene Similarity metric (BM25, Tf/idf)
+    * @return Returns top-k linked results as RDD of [[Tuple2]] where _1 is query and
+    *         _2 is top-k linked results as [[SparkScoreDoc]].
     */
   def blockEntityLinkage(queries: DataFrame,
-                         corpus: DataFrame,
+                         entities: DataFrame,
                          rowToQueryString: Row => String,
-                         queriesPartColumns: Array[String],
-                         corpusPartColumns: Array[String],
+                         queryPartColumns: Array[String],
+                         entityPartColumns: Array[String],
                          topK : Int = 3,
                          indexAnalyzer: String = getOrElseEn(IndexAnalyzerConfigName),
                          queryAnalyzer: String = getOrElseEn(QueryAnalyzerConfigName),
                          similarity: String = getOrElseClassic())
   : RDD[(Row, Array[SparkScoreDoc])] = {
 
-    import org.apache.spark.sql.functions._
+    val partColumn = "__PARTITION_COLUMN__"
 
-    val partColumn = "PARTITION_COLUMN"
-    val blocked = corpus.withColumn(partColumn,
-      concat(corpusPartColumns.map(corpus.col): _*))
+    // Prepare input DataFrames for cogroup operation.
+    // Keyed them on queryPartColumns and entityPartColumns
+    // I.e., Query/Entity DataFrame are now of type (String, Row)
+    val blocked = entities.withColumn(partColumn,
+      concat(entityPartColumns.map(entities.col): _*))
       .rdd.keyBy(x => x.getString(x.fieldIndex(partColumn)))
     val blockedQueries = queries.withColumn(partColumn,
-      concat(corpusPartColumns.map(corpus.col): _*))
+      concat(entityPartColumns.map(entities.col): _*))
       .rdd.keyBy(x => x.getString(x.fieldIndex(partColumn)))
 
-    val output = blockedQueries.cogroup(blocked)
+    // Cogroup queries and entities. Map over each
+    // CoGrouped partition and instantiate Lucene index on partitioned
+    // entities. Query lucene index for all partitioned queries
+    blockedQueries.cogroup(blocked)
       .mapPartitionsWithIndex{ case (idx, iterKeyedByHash) =>
-        iterKeyedByHash.flatMap { case (_, (qs, lucene)) =>
-          val lucenePart = LuceneRDDPartition(lucene.toIterator, idx, indexAnalyzer,
+        iterKeyedByHash.flatMap { case (_, (qs, ents)) =>
+
+          // Instantiate a lucene index on partitioned entities
+          val lucenePart = LuceneRDDPartition(ents.toIterator, idx, indexAnalyzer,
             queryAnalyzer, similarity)
 
+          // Multi-query lucene index
           qs.map(q => (q, lucenePart.query(rowToQueryString(q), topK).results.toArray))
         }
     }
-
-    output
   }
 }

--- a/src/test/scala/org/zouzias/spark/lucenerdd/BlockingLinkageSpec.scala
+++ b/src/test/scala/org/zouzias/spark/lucenerdd/BlockingLinkageSpec.scala
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zouzias.spark.lucenerdd
+
+import com.holdenkarau.spark.testing.SharedSparkContext
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.{Row, SparkSession}
+import org.scalatest.{BeforeAndAfterEach, FlatSpec, Matchers}
+import org.zouzias.spark.lucenerdd.testing.Person
+
+class BlockingLinkageSpec extends FlatSpec
+  with Matchers
+  with BeforeAndAfterEach
+  with SharedSparkContext {
+
+  override val conf: SparkConf = LuceneRDDKryoRegistrator.registerKryoClasses(new SparkConf().
+    setMaster("local[*]").
+    setAppName("test").
+    set("spark.ui.enabled", "false").
+    set("spark.app.id", appID))
+
+  "LuceneRDD.blockEntityLinkage" should "deduplicate elements on unique elements" in {
+    val spark = SparkSession.builder().getOrCreate()
+    import spark.implicits._
+
+    val people: Array[Person] = Array("fear", "death", "water", "fire", "house")
+      .zipWithIndex.map { case (str, index) =>
+      val email = if (index % 2 == 0) "yes@gmail.com" else "no@gmail.com"
+      Person(str, index, email)
+    }
+    val df = sc.parallelize(people).repartition(2).toDF()
+
+    val linker: Row => String = { row =>
+      val name = row.getString(row.fieldIndex("name"))
+
+      s"name:$name"
+    }
+
+
+    val linked = LuceneRDD.blockEntityLinkage(df, df, linker,
+      Array("email"), Array("email"))
+
+    val linkedCount, dfCount = (linked.count, df.count())
+
+    linkedCount should equal(dfCount)
+
+    // Check for correctness
+    // Age is a unique index
+    linked.collect().foreach { case (row, results) =>
+      val leftAge, rightAge = (row.getInt(row.fieldIndex("age")),
+        results.headOption.map(_.doc.numericField("age")))
+
+      leftAge should equal(rightAge)
+
+    }
+  }
+}


### PR DESCRIPTION
Introduce method `LuceneRDD. blockEntityLinkage` with performs record linkage by hash partition both datasets based on one or more columns.

For example, for deduplication of a DataFrame where there is a categorical column (e.g. country), it could be used on the hash partitioning strategy.