### PR TITLE
Release 0.3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,16 +16,16 @@ matrix:
   include:
     - jdk: oraclejdk8
       scala: 2.11.12
-      env: TEST_SPARK_VERSION="2.2.1" LUCENE_ANALYZER="en" LINKER_METHOD="cartesian"
+      env: TEST_SPARK_VERSION="2.3.0" LUCENE_ANALYZER="en" LINKER_METHOD="cartesian"
     - jdk: openjdk8
       scala: 2.11.12
-      env: TEST_SPARK_VERSION="2.2.1" LUCENE_ANALYZER="en" LINKER_METHOD="collectbroadcast"
+      env: TEST_SPARK_VERSION="2.3.0" LUCENE_ANALYZER="en" LINKER_METHOD="collectbroadcast"
     - jdk: openjdk8
       scala: 2.11.12
-      env: TEST_SPARK_VERSION="2.2.1" LUCENE_ANALYZER="whitespace" LINKER_METHOD="cartesian"
+      env: TEST_SPARK_VERSION="2.3.0" LUCENE_ANALYZER="whitespace" LINKER_METHOD="cartesian"
     - jdk: oraclejdk8
       scala: 2.11.12
-      env: TEST_SPARK_VERSION="2.2.1" LUCENE_ANALYZER="whitespace" LINKER_METHOD="collectbroadcast"
+      env: TEST_SPARK_VERSION="2.3.0" LUCENE_ANALYZER="whitespace" LINKER_METHOD="collectbroadcast"
 script:
   - sbt ++$TRAVIS_SCALA_VERSION clean update
       -Dlucenerdd.linker.method=${LINKER_METHOD}

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,16 +16,16 @@ matrix:
   include:
     - jdk: oraclejdk8
       scala: 2.11.12
-      env: TEST_SPARK_VERSION="2.3.0" LUCENE_ANALYZER="en" LINKER_METHOD="cartesian"
+      env: TEST_SPARK_VERSION="2.3.1" LUCENE_ANALYZER="en" LINKER_METHOD="cartesian"
     - jdk: openjdk8
       scala: 2.11.12
-      env: TEST_SPARK_VERSION="2.3.0" LUCENE_ANALYZER="en" LINKER_METHOD="collectbroadcast"
+      env: TEST_SPARK_VERSION="2.3.1" LUCENE_ANALYZER="en" LINKER_METHOD="collectbroadcast"
     - jdk: openjdk8
       scala: 2.11.12
-      env: TEST_SPARK_VERSION="2.3.0" LUCENE_ANALYZER="whitespace" LINKER_METHOD="cartesian"
+      env: TEST_SPARK_VERSION="2.3.1" LUCENE_ANALYZER="whitespace" LINKER_METHOD="cartesian"
     - jdk: oraclejdk8
       scala: 2.11.12
-      env: TEST_SPARK_VERSION="2.3.0" LUCENE_ANALYZER="whitespace" LINKER_METHOD="collectbroadcast"
+      env: TEST_SPARK_VERSION="2.3.1" LUCENE_ANALYZER="whitespace" LINKER_METHOD="collectbroadcast"
 script:
   - sbt ++$TRAVIS_SCALA_VERSION clean update
       -Dlucenerdd.linker.method=${LINKER_METHOD}

--- a/build.sbt
+++ b/build.sbt
@@ -80,7 +80,7 @@ pomExtra := <scm>
 val luceneV = "7.3.0"
 
 spName := "zouzias/spark-lucenerdd"
-sparkVersion := "2.2.1"
+sparkVersion := "2.3.0"
 spShortDescription := "Spark RDD with Lucene's query capabilities"
 sparkComponents ++= Seq("core", "sql", "mllib")
 spAppendScalaVersion := true
@@ -135,7 +135,7 @@ libraryDependencies ++= Seq(
 libraryDependencies ++= Seq(
   "org.apache.spark" %% "spark-core" % testSparkVersion.value % "test" force(),
   "org.apache.spark" %% "spark-sql" % testSparkVersion.value % "test" force(),
-  "com.holdenkarau"  %% "spark-testing-base" % s"2.2.1_0.9.0" % "test" intransitive(),
+  "com.holdenkarau"  %% "spark-testing-base" % s"2.3.0_0.9.0" % "test" intransitive(),
   "org.scala-lang"    % "scala-library" % scalaVersion.value % "compile"
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -77,10 +77,10 @@ pomExtra := <scm>
     </developer>
   </developers>
 
-val luceneV = "7.3.1"
+val luceneV = "7.4.0"
 
 spName := "zouzias/spark-lucenerdd"
-sparkVersion := "2.3.0"
+sparkVersion := "2.3.1"
 spShortDescription := "Spark RDD with Lucene's query capabilities"
 sparkComponents ++= Seq("core", "sql", "mllib")
 spAppendScalaVersion := true
@@ -99,7 +99,7 @@ val scalatest                 = "org.scalatest"                  %% "scalatest" 
 
 val joda_time                 = "joda-time"                      % "joda-time"                 % "2.9.9"
 val algebird                  = "com.twitter"                    %% "algebird-core"            % "0.13.4"
-val joda_convert              = "org.joda"                       % "joda-convert"              % "2.0.1"
+val joda_convert              = "org.joda"                       % "joda-convert"              % "2.0.2"
 val spatial4j                 = "org.locationtech.spatial4j"     % "spatial4j"                 % "0.7"
 
 val typesafe_config           = "com.typesafe"                   % "config"                    % "1.3.3"

--- a/build.sbt
+++ b/build.sbt
@@ -77,7 +77,7 @@ pomExtra := <scm>
     </developer>
   </developers>
 
-val luceneV = "7.3.0"
+val luceneV = "7.3.1"
 
 spName := "zouzias/spark-lucenerdd"
 sparkVersion := "2.3.0"

--- a/build.sbt
+++ b/build.sbt
@@ -97,9 +97,9 @@ testSparkVersion := sys.props.get("spark.testVersion").getOrElse(sparkVersion.va
 val scalactic                 = "org.scalactic"                  %% "scalactic"                % "3.0.5"
 val scalatest                 = "org.scalatest"                  %% "scalatest"                % "3.0.5" % "test"
 
-val joda_time                 = "joda-time"                      % "joda-time"                 % "2.9.9"
+val joda_time                 = "joda-time"                      % "joda-time"                 % "2.10"
 val algebird                  = "com.twitter"                    %% "algebird-core"            % "0.13.4"
-val joda_convert              = "org.joda"                       % "joda-convert"              % "2.0.2"
+val joda_convert              = "org.joda"                       % "joda-convert"              % "2.1"
 val spatial4j                 = "org.locationtech.spatial4j"     % "spatial4j"                 % "0.7"
 
 val typesafe_config           = "com.typesafe"                   % "config"                    % "1.3.3"
@@ -111,7 +111,7 @@ val lucene_expressions        = "org.apache.lucene"              % "lucene-expre
 val lucene_spatial            = "org.apache.lucene"              % "lucene-spatial"            % luceneV
 val lucene_spatial_extras     = "org.apache.lucene"              % "lucene-spatial-extras"     % luceneV
 
-val jts                       = "org.locationtech.jts"           % "jts-core"                  % "1.15.0"
+val jts                       = "org.locationtech.jts"           % "jts-core"                  % "1.15.1"
 // scalastyle:on
 
 
@@ -135,7 +135,7 @@ libraryDependencies ++= Seq(
 libraryDependencies ++= Seq(
   "org.apache.spark" %% "spark-core" % testSparkVersion.value % "test" force(),
   "org.apache.spark" %% "spark-sql" % testSparkVersion.value % "test" force(),
-  "com.holdenkarau"  %% "spark-testing-base" % s"2.3.0_0.9.0" % "test" intransitive(),
+  "com.holdenkarau"  %% "spark-testing-base" % s"2.3.1_0.10.0" % "test" intransitive(),
   "org.scala-lang"    % "scala-library" % scalaVersion.value % "compile"
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -99,7 +99,7 @@ val scalatest                 = "org.scalatest"                  %% "scalatest" 
 
 val joda_time                 = "joda-time"                      % "joda-time"                 % "2.9.9"
 val algebird                  = "com.twitter"                    %% "algebird-core"            % "0.13.4"
-val joda_convert              = "org.joda"                       % "joda-convert"              % "1.9.2"
+val joda_convert              = "org.joda"                       % "joda-convert"              % "2.0.1"
 val spatial4j                 = "org.locationtech.spatial4j"     % "spatial4j"                 % "0.7"
 
 val typesafe_config           = "com.typesafe"                   % "config"                    % "1.3.3"

--- a/build.sbt
+++ b/build.sbt
@@ -99,7 +99,7 @@ val scalatest                 = "org.scalatest"                  %% "scalatest" 
 
 val joda_time                 = "joda-time"                      % "joda-time"                 % "2.10"
 val algebird                  = "com.twitter"                    %% "algebird-core"            % "0.13.4"
-val joda_convert              = "org.joda"                       % "joda-convert"              % "2.1"
+val joda_convert              = "org.joda"                       % "joda-convert"              % "2.1.1"
 val spatial4j                 = "org.locationtech.spatial4j"     % "spatial4j"                 % "0.7"
 
 val typesafe_config           = "com.typesafe"                   % "config"                    % "1.3.3"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.16
+sbt.version=0.13.17

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -19,16 +19,16 @@ resolvers += "bintray-spark-packages" at "https://dl.bintray.com/spark-packages/
 
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.6")
 
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.6")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.8")
 
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.9.0")
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.0")
 
-addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.1.0")
+addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.2.4")
 
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")
 
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.1")
 
 addSbtPlugin("org.spark-packages" % "sbt-spark-package" % "0.2.6")

--- a/spark-shell.sh
+++ b/spark-shell.sh
@@ -6,7 +6,7 @@ CURRENT_DIR=`pwd`
 SPARK_LUCENERDD_VERSION=`cat version.sbt | awk '{print $5}' | xargs`
 
 # You should have downloaded this spark version under your ${HOME}
-SPARK_VERSION="2.2.0"
+SPARK_VERSION="2.3.0"
 
 echo "==============================================="
 echo "Loading LuceneRDD with version ${SPARK_LUCENERDD_VERSION}"

--- a/src/main/scala/org/zouzias/spark/lucenerdd/LuceneRDD.scala
+++ b/src/main/scala/org/zouzias/spark/lucenerdd/LuceneRDD.scala
@@ -519,4 +519,31 @@ object LuceneRDD extends Versionable
         }
     }
   }
+
+  /**
+    * Deduplication via blocking
+    *
+    * @param entities Entities [[DataFrame]] to deduplicate
+    * @param rowToQueryString Function that maps [[Row]] to Lucene Query String
+    * @param blockingColumns Columns on which exact match is required
+    * @param topK Number of top-K query results
+    * @param indexAnalyzer Lucene analyzer at index time
+    * @param queryAnalyzer Lucene analyzer at query time
+    * @param similarity Lucene Similarity metric (BM25, Tf/idf)
+    * @return Returns top-k deduplicated results as [[RDD]] of [[Tuple2]] where _1 is query and
+    *         _2 is top-k linked results as [[SparkScoreDoc]].
+    * @return
+    */
+  def blockDedup(entities: DataFrame,
+                 rowToQueryString: Row => String,
+                 blockingColumns: Array[String],
+                 topK : Int = 3,
+                 indexAnalyzer: String = getOrElseEn(IndexAnalyzerConfigName),
+                 queryAnalyzer: String = getOrElseEn(QueryAnalyzerConfigName),
+                 similarity: String = getOrElseClassic())
+  : RDD[(Row, Array[SparkScoreDoc])] = {
+    blockEntityLinkage(entities, entities, rowToQueryString,
+      blockingColumns, blockingColumns, topK, indexAnalyzer,
+      queryAnalyzer, similarity)
+  }
 }

--- a/src/main/scala/org/zouzias/spark/lucenerdd/LuceneRDD.scala
+++ b/src/main/scala/org/zouzias/spark/lucenerdd/LuceneRDD.scala
@@ -491,6 +491,12 @@ object LuceneRDD extends Versionable
                          similarity: String = getOrElseClassic())
   : RDD[(Row, Array[SparkScoreDoc])] = {
 
+    assert(entityPartColumns.nonEmpty,
+      "Entity Partition columns must be non-empty for block linkage")
+    assert(queryPartColumns.nonEmpty,
+      "Query Partition columns must be non-empty for block linkage")
+
+
     val partColumn = "__PARTITION_COLUMN__"
 
     // Prepare input DataFrames for cogroup operation.
@@ -542,6 +548,9 @@ object LuceneRDD extends Versionable
                  queryAnalyzer: String = getOrElseEn(QueryAnalyzerConfigName),
                  similarity: String = getOrElseClassic())
   : RDD[(Row, Array[SparkScoreDoc])] = {
+
+    // Check that there is at least one partition column
+    assert(blockingColumns.nonEmpty, "Partition columns must be non-empty for block deduplication")
 
     val partColumn = "__PARTITION_COLUMN__"
     val blocked = entities.withColumn(partColumn,

--- a/src/test/scala/org/zouzias/spark/lucenerdd/BlockingDedupSpec.scala
+++ b/src/test/scala/org/zouzias/spark/lucenerdd/BlockingDedupSpec.scala
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zouzias.spark.lucenerdd
+
+import com.holdenkarau.spark.testing.SharedSparkContext
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.{Row, SparkSession}
+import org.scalatest.{BeforeAndAfterEach, FlatSpec, Matchers}
+import org.zouzias.spark.lucenerdd.testing.Person
+
+class BlockingDedupSpec extends FlatSpec
+  with Matchers
+  with BeforeAndAfterEach
+  with SharedSparkContext {
+
+  override val conf: SparkConf = LuceneRDDKryoRegistrator.registerKryoClasses(new SparkConf().
+    setMaster("local[*]").
+    setAppName("test").
+    set("spark.ui.enabled", "false").
+    set("spark.app.id", appID))
+
+  "LuceneRDD.blockDedup" should "deduplicate elements on unique elements" in {
+    val spark = SparkSession.builder().getOrCreate()
+    import spark.implicits._
+
+    val people: Array[Person] = Array("fear", "death", "water", "fire", "house")
+      .zipWithIndex.map { case (str, index) =>
+      val email = if (index % 2 == 0) "yes@gmail.com" else "no@gmail.com"
+      Person(str, index, email)
+    }
+    val df = sc.parallelize(people).repartition(2).toDF()
+
+    val linker: Row => String = { row =>
+      val name = row.getString(row.fieldIndex("name"))
+
+      s"name:$name"
+    }
+
+
+    val linked = LuceneRDD.blockDedup(df, linker, Array("email"))
+
+    val linkedCount, dfCount = (linked.count, df.count())
+
+    linkedCount should equal(dfCount)
+
+    // Check for correctness
+    // Age is a unique index
+    linked.collect().foreach { case (row, results) =>
+      val leftAge, rightAge = (row.getInt(row.fieldIndex("age")),
+        results.headOption.map(_.doc.numericField("age")))
+
+      leftAge should equal(rightAge)
+
+    }
+  }
+}


### PR DESCRIPTION
Prepare for release

Changelog:
* SBT plugins updates
* Update to Spark 2.3.1
* Update to Lucene 7.4.0
* Improve block deduplication method under `LuceneRDD. blockDedup` by replacing the `cogroup` operation with a single `HashPartitioner` on the data, i.e., exploit the deduplication problem structure a bit further.