### PR TITLE
Prepare for release

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ The main abstractions are special types of `RDD` called `LuceneRDD`, `FacetedLuc
 |Bbox Search| `ShapeLuceneRDD.bboxSearch(lowerLeft, upperLeft, topK)` | Bounding box |
 |Spatial Linkage| `ShapeLuceneRDD.linkByRadius(RDD[T], linkage: T => (x,y), radius, topK)` | Spatial radius linkage|
 
-Using the query parser, you can perform prefix queries, fuzzy queries, prefix queries, etc and any combination of those. 
-For more information on using Lucene's query parser, see [Query Parser](https://lucene.apache.org/core/5_5_0/queryparser/org/apache/lucene/queryparser/classic/QueryParser.html). 
+Using the query parser, you can perform prefix queries, fuzzy queries, prefix queries, etc and any combination of those.
+For more information on using Lucene's query parser, see [Query Parser](https://lucene.apache.org/core/5_5_0/queryparser/org/apache/lucene/queryparser/classic/QueryParser.html).
 
 ### [Examples](https://github.com/zouzias/spark-lucenerdd-examples)
 
@@ -78,7 +78,7 @@ Artifact                  | Release Date    | Spark compatibility | Notes | Stat
 ------------------------- | --------------- | -------------------------- | ----- | ----
 0.3.5-SNAPSHOT            |                 | >= 2.3.1, JVM 8  | [develop](https://github.com/zouzias/spark-lucenerdd/tree/develop) | Under Development
 0.3.4                     |  2018-11-27     | >= 2.4.0, JVM 8  | [tag v0.3.4](https://github.com/zouzias/spark-lucenerdd/tree/v0.3.4) | Released
-0.2.8                     | 2017-05-30      |  2.1.x, JVM 7      | [tag v0.2.8](https://github.com/zouzias/spark-lucenerdd/tree/v0.2.8) | Released 
+0.2.8                     | 2017-05-30      |  2.1.x, JVM 7      | [tag v0.2.8](https://github.com/zouzias/spark-lucenerdd/tree/v0.2.8) | Released
 0.1.0                     | 2016-09-26      | 1.4.x, 1.5.x, 1.6.x| [tag v0.1.0](https://github.com/zouzias/spark-lucenerdd/tree/v0.1.0) | Cross-released with 2.10/2.11
 
 ### Project Status and Limitations
@@ -101,7 +101,7 @@ A docker compose script is setup with some preliminary notebook in Zeppelin, run
 docker-compose up
 ```
 
-For more LuceneRDD examples on Zeppelin, check these [examples](https://github.com/zouzias/spark-lucenerdd-examples) 
+For more LuceneRDD examples on Zeppelin, check these [examples](https://github.com/zouzias/spark-lucenerdd-examples)
 ### Build from Source
 
 Install Java, [SBT](http://www.scala-sbt.org) and clone the project

--- a/build.sbt
+++ b/build.sbt
@@ -135,7 +135,7 @@ libraryDependencies ++= Seq(
 libraryDependencies ++= Seq(
   "org.apache.spark" %% "spark-core" % testSparkVersion.value % "test" force(),
   "org.apache.spark" %% "spark-sql" % testSparkVersion.value % "test" force(),
-  "com.holdenkarau"  %% "spark-testing-base" % s"2.3.1_0.10.0" % "test" intransitive(),
+  "com.holdenkarau"  %% "spark-testing-base" % s"2.4.0_0.11.0" % "test" intransitive(),
   "org.scala-lang"    % "scala-library" % scalaVersion.value % "compile"
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -99,7 +99,7 @@ val scalatest                 = "org.scalatest"                  %% "scalatest" 
 
 val joda_time                 = "joda-time"                      % "joda-time"                 % "2.10.1"
 val algebird                  = "com.twitter"                    %% "algebird-core"            % "0.13.5"
-val joda_convert              = "org.joda"                       % "joda-convert"              % "2.1.2"
+val joda_convert              = "org.joda"                       % "joda-convert"              % "2.2.0"
 val spatial4j                 = "org.locationtech.spatial4j"     % "spatial4j"                 % "0.7"
 
 val typesafe_config           = "com.typesafe"                   % "config"                    % "1.3.3"

--- a/build.sbt
+++ b/build.sbt
@@ -77,7 +77,7 @@ pomExtra := <scm>
     </developer>
   </developers>
 
-val luceneV = "7.5.0"
+val luceneV = "7.6.0"
 
 spName := "zouzias/spark-lucenerdd"
 sparkVersion := "2.4.0"

--- a/build.sbt
+++ b/build.sbt
@@ -17,8 +17,8 @@
 
 name := "spark-lucenerdd"
 organization := "org.zouzias"
-scalaVersion := "2.11.12"
-crossScalaVersions := Seq("2.11.12")
+scalaVersion := "2.12.7"
+crossScalaVersions := Seq("2.11.12", "2.12.7")
 licenses := Seq("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0.html"))
 homepage := Some(url("https://github.com/zouzias/spark-lucenerdd"))
 

--- a/build.sbt
+++ b/build.sbt
@@ -17,8 +17,8 @@
 
 name := "spark-lucenerdd"
 organization := "org.zouzias"
-scalaVersion := "2.12.7"
-crossScalaVersions := Seq("2.11.12", "2.12.7")
+scalaVersion := "2.11.12"
+crossScalaVersions := Seq("2.11.12")
 licenses := Seq("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0.html"))
 homepage := Some(url("https://github.com/zouzias/spark-lucenerdd"))
 

--- a/src/main/scala/org/zouzias/spark/lucenerdd/LuceneRDD.scala
+++ b/src/main/scala/org/zouzias/spark/lucenerdd/LuceneRDD.scala
@@ -69,7 +69,7 @@ class LuceneRDD[T: ClassTag](protected val partitionsRDD: RDD[AbstractLuceneRDDP
 
   override def persist(newLevel: StorageLevel): this.type = {
     partitionsRDD.persist(newLevel)
-    super.persist(newLevel)
+    super.persist(StorageLevel.DISK_ONLY)
     this
   }
 

--- a/src/main/scala/org/zouzias/spark/lucenerdd/config/LuceneRDDConfigurable.scala
+++ b/src/main/scala/org/zouzias/spark/lucenerdd/config/LuceneRDDConfigurable.scala
@@ -111,4 +111,19 @@ trait LuceneRDDConfigurable extends Configurable {
     }
     else "collectbroadcast"  // collectbroadcast by default
   }
+
+  /**
+    *
+    * @param fieldName Name of field
+    * @return Returns true, if field must be analyzed
+    */
+  protected def isAnalyzedField(fieldName: String): Boolean = {
+    if (StringFieldsListToBeNotAnalyzed.contains(fieldName)) {
+      false
+    }
+    else {
+      // Return the default string field analysis option
+      StringFieldsDefaultAnalyzed
+    }
+  }
 }

--- a/src/main/scala/org/zouzias/spark/lucenerdd/config/LuceneRDDConfigurable.scala
+++ b/src/main/scala/org/zouzias/spark/lucenerdd/config/LuceneRDDConfigurable.scala
@@ -111,19 +111,4 @@ trait LuceneRDDConfigurable extends Configurable {
     }
     else "collectbroadcast"  // collectbroadcast by default
   }
-
-  /**
-    *
-    * @param fieldName Name of field
-    * @return Returns true, if field must be analyzed
-    */
-  protected def isAnalyzedField(fieldName: String): Boolean = {
-    if (StringFieldsListToBeNotAnalyzed.contains(fieldName)) {
-      false
-    }
-    else {
-      // Return the default string field analysis option
-      StringFieldsDefaultAnalyzed
-    }
-  }
 }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.3.4"
+version in ThisBuild := "0.3.5-SNAPSHOT"


### PR DESCRIPTION
Changelog:
* Persist RDD to disk to reduce memory footprint of LuceneRDD, see [here](https://github.com/zouzias/spark-lucenerdd/pull/149/commits/d8e625672834a1685a441299af014cd6fd5a8d07)
* Allow users to select which fields to not analyze, i.e., by configuration file or any field ending with `_notanalyzed`
* Update to Lucene 7.6.0