### PR TITLE
Allow Lucene Analyzers per field

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -94,8 +94,8 @@ testSparkVersion := sys.props.get("spark.testVersion").getOrElse(sparkVersion.va
 
 
 // scalastyle:off
-val scalactic                 = "org.scalactic"                  %% "scalactic"                % "3.0.6"
-val scalatest                 = "org.scalatest"                  %% "scalatest"                % "3.0.6" % "test"
+val scalactic                 = "org.scalactic"                  %% "scalactic"                % "3.0.7"
+val scalatest                 = "org.scalatest"                  %% "scalatest"                % "3.0.7" % "test"
 
 val joda_time                 = "joda-time"                      % "joda-time"                 % "2.10.1"
 val algebird                  = "com.twitter"                    %% "algebird-core"            % "0.13.5"

--- a/src/main/scala/org/zouzias/spark/lucenerdd/LuceneRDD.scala
+++ b/src/main/scala/org/zouzias/spark/lucenerdd/LuceneRDD.scala
@@ -430,6 +430,19 @@ object LuceneRDD extends Versionable
   }
 
   def apply[T : ClassTag]
+  (elems: RDD[T])
+  (implicit conv: T => Document)
+  : LuceneRDD[T] = {
+    apply[T](elems,
+      getOrElseEn(IndexAnalyzerConfigName),
+      getOrElseEn(QueryAnalyzerConfigName),
+      getOrElseClassic(),
+      Map.empty[String, String],
+      Map.empty[String, String])
+  }
+
+
+  def apply[T : ClassTag]
   (elems: Iterable[T])
   (implicit sc: SparkContext, conv: T => Document)
   : LuceneRDD[T] = {

--- a/src/main/scala/org/zouzias/spark/lucenerdd/LuceneRDD.scala
+++ b/src/main/scala/org/zouzias/spark/lucenerdd/LuceneRDD.scala
@@ -19,7 +19,7 @@ package org.zouzias.spark.lucenerdd
 
 import com.twitter.algebird.{TopK, TopKMonoid}
 import org.apache.lucene.document.Document
-import org.zouzias.spark.lucenerdd.config.LuceneRDDConfigurable
+import org.zouzias.spark.lucenerdd.config.{LuceneRDDConfigurable, LuceneRDDParams}
 import org.zouzias.spark.lucenerdd.response.{LuceneRDDResponse, LuceneRDDResponsePartition}
 import org.apache.spark.rdd.RDD
 import org.apache.lucene.search.Query
@@ -48,6 +48,8 @@ import scala.reflect.ClassTag
 class LuceneRDD[T: ClassTag](protected val partitionsRDD: RDD[AbstractLuceneRDDPartition[T]],
                              protected val indexAnalyzer: String,
                              protected val queryAnalyzer: String,
+                             protected val indexAnalyzerPerField: Map[String, String],
+                             protected val queryAnalyzerPerField: Map[String, String],
                              protected val similarity: String)
   extends RDD[T](partitionsRDD.context, List(new OneToOneDependency(partitionsRDD)))
   with LuceneRDDConfigurable {
@@ -356,7 +358,8 @@ class LuceneRDD[T: ClassTag](protected val partitionsRDD: RDD[AbstractLuceneRDDP
     val newPartitionRDD = partitionsRDD.mapPartitions(partition =>
       partition.map(_.filter(pred)), preservesPartitioning = true
     )
-    new LuceneRDD(newPartitionRDD, indexAnalyzer, queryAnalyzer, similarity)
+    new LuceneRDD(newPartitionRDD, indexAnalyzer, queryAnalyzer,
+      indexAnalyzerPerField, queryAnalyzerPerField, similarity)
   }
 
   def exists(elem: T): Boolean = {
@@ -377,37 +380,38 @@ object LuceneRDD extends Versionable
    * Instantiate a LuceneRDD given an RDD[T]
    *
    * @param elems RDD of type T
-   * @param indexAnalyzer Index Analyzer name
-   * @param queryAnalyzer Query Analyzer name
+   * @param indexAnalyzer Index analyzer name
+   * @param queryAnalyzer Query analyzer name
    * @param similarity Lucene scoring similarity, i.e., BM25 or TF-IDF
+   * @param indexAnalyzerPerField Lucene Analyzer per field (indexing time), default empty
+   * @param queryAnalyzerPerField Lucene Analyzer per field (query time), default empty
    * @tparam T Generic type
    * @return
    */
   def apply[T : ClassTag](elems: RDD[T],
                           indexAnalyzer: String,
                           queryAnalyzer: String,
-                          similarity: String)
+                          similarity: String,
+                          indexAnalyzerPerField: Map[String, String] = Map.empty[String, String],
+                          queryAnalyzerPerField: Map[String, String] = Map.empty[String, String])
     (implicit conv: T => Document): LuceneRDD[T] = {
     val partitions = elems.mapPartitionsWithIndex[AbstractLuceneRDDPartition[T]](
       (partId, iter) => Iterator(LuceneRDDPartition(iter, partId, indexAnalyzer, queryAnalyzer,
         similarity)),
       preservesPartitioning = true)
-    new LuceneRDD[T](partitions, indexAnalyzer, queryAnalyzer, similarity)
-  }
-
-  def apply[T : ClassTag](elems: RDD[T])
-                         (implicit conv: T => Document): LuceneRDD[T] = {
-   apply(elems, getOrElseEn(IndexAnalyzerConfigName), getOrElseEn(QueryAnalyzerConfigName),
-     getOrElseClassic())
+    new LuceneRDD[T](partitions, indexAnalyzer, queryAnalyzer,
+      indexAnalyzerPerField, queryAnalyzerPerField, similarity)
   }
 
   /**
    * Instantiate a LuceneRDD with an iterable
    *
    * @param elems Elements to index
-   * @param indexAnalyzer Index Analyzer name
-   * @param queryAnalyzer Query Analyzer name
+   * @param indexAnalyzer Index analyzer name
+   * @param queryAnalyzer Query analyzer name
    * @param similarity Lucene scoring similarity, i.e., BM25 or TF-IDF
+   * @param indexAnalyzerPerField Lucene Analyzer per field (indexing time), default empty
+   * @param queryAnalyzerPerField Lucene Analyzer per field (query time), default empty
    * @param sc Spark Context
    * @tparam T Input type
    * @return
@@ -416,10 +420,13 @@ object LuceneRDD extends Versionable
   (elems: Iterable[T],
    indexAnalyzer: String,
    queryAnalyzer: String,
-   similarity: String)
+   similarity: String,
+   indexAnalyzerPerField: Map[String, String] = Map.empty[String, String],
+   queryAnalyzerPerField: Map[String, String] = Map.empty[String, String])
   (implicit sc: SparkContext, conv: T => Document)
   : LuceneRDD[T] = {
-    apply[T](sc.parallelize[T](elems.toSeq), indexAnalyzer, queryAnalyzer, similarity)
+    apply[T](sc.parallelize[T](elems.toSeq), indexAnalyzer, queryAnalyzer, similarity,
+      indexAnalyzerPerField, queryAnalyzerPerField)
   }
 
   def apply[T : ClassTag]
@@ -433,18 +440,17 @@ object LuceneRDD extends Versionable
   }
 
   /**
-   * Instantiate a LuceneRDD with DataFrame
+   * Instantiate a LuceneRDD from a  [[DataFrame]]
    *
-   * @param dataFrame Spark DataFrame
-   * @param indexAnalyzer Index Analyzer name
-   * @param queryAnalyzer Query Analyzer name
-   * @param similarity Lucene scoring similarity, i.e., BM25 or TF-IDF
-    * @return
+   * @param dataFrame Spark [[DataFrame]]
+   * @return
    */
   def apply(dataFrame: DataFrame,
             indexAnalyzer: String,
             queryAnalyzer: String,
-            similarity: String)
+            similarity: String,
+            indexAnalyzerPerField: Map[String, String] = Map.empty[String, String],
+            queryAnalyzerPerField: Map[String, String] = Map.empty[String, String])
   : LuceneRDD[Row] = {
     apply[Row](dataFrame.rdd, indexAnalyzer, queryAnalyzer, similarity)
   }
@@ -473,9 +479,7 @@ object LuceneRDD extends Versionable
     * @param queryPartColumns List of query columns for [[HashPartitioner]]
     * @param entityPartColumns List of entity columns for [[HashPartitioner]]
     * @param topK Number of linked results
-    * @param indexAnalyzer Lucene analyzer at index time
-    * @param queryAnalyzer Lucene analyzer at query time
-    * @param similarity Lucene Similarity metric (BM25, Tf/idf)
+    * @param luceneRDDParams Parameters for index and query time analysis
     * @return Returns top-k linked results as RDD of [[Tuple2]] where _1 is query and
     *         _2 is top-k linked results as [[SparkScoreDoc]].
     */
@@ -485,9 +489,7 @@ object LuceneRDD extends Versionable
                          queryPartColumns: Array[String],
                          entityPartColumns: Array[String],
                          topK : Int = 3,
-                         indexAnalyzer: String = getOrElseEn(IndexAnalyzerConfigName),
-                         queryAnalyzer: String = getOrElseEn(QueryAnalyzerConfigName),
-                         similarity: String = getOrElseClassic())
+                         luceneRDDParams: LuceneRDDParams = LuceneRDDParams())
   : RDD[(Row, Array[SparkScoreDoc])] = {
 
     assert(entityPartColumns.nonEmpty,
@@ -517,8 +519,12 @@ object LuceneRDD extends Versionable
         iterKeyedByHash.flatMap { case (_, (qs, ents)) =>
 
           // Instantiate a lucene index on partitioned entities
-          val lucenePart = LuceneRDDPartition(ents.toIterator, idx, indexAnalyzer,
-            queryAnalyzer, similarity)
+          val lucenePart = LuceneRDDPartition(ents.toIterator, idx,
+            luceneRDDParams.indexAnalyzer,
+            luceneRDDParams.queryAnalyzer,
+            luceneRDDParams.similarity,
+            luceneRDDParams.indexAnalyzerPerField,
+            luceneRDDParams.queryAnalyzerPerField)
 
           // Multi-query lucene index
           qs.map(q => (q, lucenePart.query(rowToQuery(q), topK).results.toArray))
@@ -533,9 +539,7 @@ object LuceneRDD extends Versionable
     * @param rowToQuery Function that maps [[Row]] to Lucene [[Query]]
     * @param blockingColumns Columns on which exact match is required
     * @param topK Number of top-K query results
-    * @param indexAnalyzer Lucene analyzer at index time
-    * @param queryAnalyzer Lucene analyzer at query time
-    * @param similarity Lucene Similarity metric (BM25, Tf/idf)
+    * @param luceneRDDParams Parameters for index-time and query-time analysis
     * @return Returns top-k deduplicated results as [[RDD]] of [[Tuple2]] where _1 is query and
     *         _2 is top-k linked results as [[SparkScoreDoc]].
     * @return
@@ -544,9 +548,7 @@ object LuceneRDD extends Versionable
                  rowToQuery: Row => Query,
                  blockingColumns: Array[String],
                  topK : Int = 3,
-                 indexAnalyzer: String = getOrElseEn(IndexAnalyzerConfigName),
-                 queryAnalyzer: String = getOrElseEn(QueryAnalyzerConfigName),
-                 similarity: String = getOrElseClassic())
+                 luceneRDDParams: LuceneRDDParams = LuceneRDDParams())
   : RDD[(Row, Array[SparkScoreDoc])] = {
 
     // Check that there is at least one partition column
@@ -569,7 +571,12 @@ object LuceneRDD extends Versionable
       val (iterQueries, iterLucene) = iterKeyedByHash.map(_._2).duplicate
 
       // Instantiate a lucene index on partitioned entities
-      val lucenePart = LuceneRDDPartition(iterLucene, idx, indexAnalyzer, queryAnalyzer, similarity)
+      val lucenePart = LuceneRDDPartition(iterLucene, idx,
+        luceneRDDParams.indexAnalyzer,
+        luceneRDDParams.queryAnalyzer,
+        luceneRDDParams.similarity,
+        luceneRDDParams.indexAnalyzerPerField,
+        luceneRDDParams.queryAnalyzerPerField)
 
       // Multi-query lucene index
       iterQueries.map(q => (q, lucenePart.query(rowToQuery(q), topK).results.toArray))

--- a/src/main/scala/org/zouzias/spark/lucenerdd/LuceneRDD.scala
+++ b/src/main/scala/org/zouzias/spark/lucenerdd/LuceneRDD.scala
@@ -569,10 +569,7 @@ object LuceneRDD extends Versionable
       val (iterQueries, iterLucene) = iterKeyedByHash.map(_._2).duplicate
 
       // Instantiate a lucene index on partitioned entities
-      val lucenePart = LuceneRDDPartition(iterLucene,
-        idx,
-        indexAnalyzer,
-        queryAnalyzer, similarity)
+      val lucenePart = LuceneRDDPartition(iterLucene, idx, indexAnalyzer, queryAnalyzer, similarity)
 
       // Multi-query lucene index
       iterQueries.map(q => (q, lucenePart.query(rowToQuery(q), topK).results.toArray))

--- a/src/main/scala/org/zouzias/spark/lucenerdd/LuceneRDD.scala
+++ b/src/main/scala/org/zouzias/spark/lucenerdd/LuceneRDD.scala
@@ -392,8 +392,8 @@ object LuceneRDD extends Versionable
                           indexAnalyzer: String,
                           queryAnalyzer: String,
                           similarity: String,
-                          indexAnalyzerPerField: Map[String, String] = Map.empty[String, String],
-                          queryAnalyzerPerField: Map[String, String] = Map.empty[String, String])
+                          indexAnalyzerPerField: Map[String, String],
+                          queryAnalyzerPerField: Map[String, String])
     (implicit conv: T => Document): LuceneRDD[T] = {
     val partitions = elems.mapPartitionsWithIndex[AbstractLuceneRDDPartition[T]](
       (partId, iter) => Iterator(LuceneRDDPartition(iter, partId, indexAnalyzer, queryAnalyzer,
@@ -421,8 +421,8 @@ object LuceneRDD extends Versionable
    indexAnalyzer: String,
    queryAnalyzer: String,
    similarity: String,
-   indexAnalyzerPerField: Map[String, String] = Map.empty[String, String],
-   queryAnalyzerPerField: Map[String, String] = Map.empty[String, String])
+   indexAnalyzerPerField: Map[String, String],
+   queryAnalyzerPerField: Map[String, String])
   (implicit sc: SparkContext, conv: T => Document)
   : LuceneRDD[T] = {
     apply[T](sc.parallelize[T](elems.toSeq), indexAnalyzer, queryAnalyzer, similarity,
@@ -436,7 +436,9 @@ object LuceneRDD extends Versionable
     apply[T](elems,
       getOrElseEn(IndexAnalyzerConfigName),
       getOrElseEn(QueryAnalyzerConfigName),
-      getOrElseClassic())
+      getOrElseClassic(),
+      Map.empty[String, String],
+      Map.empty[String, String])
   }
 
   /**
@@ -449,10 +451,20 @@ object LuceneRDD extends Versionable
             indexAnalyzer: String,
             queryAnalyzer: String,
             similarity: String,
-            indexAnalyzerPerField: Map[String, String] = Map.empty[String, String],
-            queryAnalyzerPerField: Map[String, String] = Map.empty[String, String])
+            indexAnalyzerPerField: Map[String, String],
+            queryAnalyzerPerField: Map[String, String])
   : LuceneRDD[Row] = {
-    apply[Row](dataFrame.rdd, indexAnalyzer, queryAnalyzer, similarity)
+    apply[Row](dataFrame.rdd, indexAnalyzer, queryAnalyzer, similarity,
+      indexAnalyzerPerField, queryAnalyzerPerField)
+  }
+
+  def apply(dataFrame: DataFrame,
+            indexAnalyzer: String,
+            queryAnalyzer: String,
+            similarity: String)
+  : LuceneRDD[Row] = {
+    apply[Row](dataFrame.rdd, indexAnalyzer, queryAnalyzer, similarity,
+      Map.empty[String, String], Map.empty[String, String])
   }
 
   /**
@@ -466,7 +478,9 @@ object LuceneRDD extends Versionable
     apply[Row](dataFrame.rdd,
       getOrElseEn(IndexAnalyzerConfigName),
       getOrElseEn(QueryAnalyzerConfigName),
-      getOrElseClassic())
+      getOrElseClassic(),
+      Map.empty[String, String],
+      Map.empty[String, String])
   }
 
   /**

--- a/src/main/scala/org/zouzias/spark/lucenerdd/config/LuceneRDDParams.scala
+++ b/src/main/scala/org/zouzias/spark/lucenerdd/config/LuceneRDDParams.scala
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.zouzias.spark.lucenerdd.config
+
+import org.apache.lucene.analysis.Analyzer
+import org.zouzias.spark.lucenerdd.analyzers.AnalyzerConfigurable
+import org.zouzias.spark.lucenerdd.query.SimilarityConfigurable
+
+ /** Lucene analysis parameters during indexing and querying.
+   *
+   * @param indexAnalyzer         Index analyzer name. Lucene [[Analyzer]] used during indexing
+   * @param queryAnalyzer         Query analyzer name. Lucene [[Analyzer]] used during querying
+   * @param similarity            Lucene scoring similarity, i.e., BM25 or TF-IDF
+   * @param indexAnalyzerPerField Lucene Analyzer per field (indexing time), default empty
+   * @param queryAnalyzerPerField Lucene Analyzer per field (query time), default empty
+   */
+case class LuceneRDDParams(indexAnalyzer: String,
+                           queryAnalyzer: String,
+                           similarity: String,
+                           indexAnalyzerPerField: Map[String, String],
+                           queryAnalyzerPerField: Map[String, String]) extends Serializable
+
+
+object LuceneRDDParams extends AnalyzerConfigurable with SimilarityConfigurable {
+
+  def apply(indexAnalyzer: String = getOrElseEn(IndexAnalyzerConfigName),
+            queryAnalyzer: String = getOrElseEn(QueryAnalyzerConfigName),
+            similarity: String = getOrElseClassic(),
+            indexAnalyzerPerField: Map[String, String] = Map.empty[String, String],
+            queryAnalyzerPerField: Map[String, String] = Map.empty[String, String])
+  : LuceneRDDParams = {
+    new LuceneRDDParams(indexAnalyzer, queryAnalyzer, similarity,
+      indexAnalyzerPerField, queryAnalyzerPerField)
+  }
+}

--- a/src/main/scala/org/zouzias/spark/lucenerdd/config/LuceneRDDParams.scala
+++ b/src/main/scala/org/zouzias/spark/lucenerdd/config/LuceneRDDParams.scala
@@ -36,17 +36,6 @@ case class LuceneRDDParams(indexAnalyzer: String,
 
 
 object LuceneRDDParams extends AnalyzerConfigurable with SimilarityConfigurable {
-
-  def apply(indexAnalyzer: String,
-            queryAnalyzer: String,
-            similarity: String,
-            indexAnalyzerPerField: Map[String, String],
-            queryAnalyzerPerField: Map[String, String])
-  : LuceneRDDParams = {
-    new LuceneRDDParams(indexAnalyzer, queryAnalyzer, similarity,
-      indexAnalyzerPerField, queryAnalyzerPerField)
-  }
-
   def apply(): LuceneRDDParams = {
     new LuceneRDDParams(getOrElseEn(IndexAnalyzerConfigName),
       getOrElseEn(QueryAnalyzerConfigName),

--- a/src/main/scala/org/zouzias/spark/lucenerdd/config/LuceneRDDParams.scala
+++ b/src/main/scala/org/zouzias/spark/lucenerdd/config/LuceneRDDParams.scala
@@ -37,13 +37,21 @@ case class LuceneRDDParams(indexAnalyzer: String,
 
 object LuceneRDDParams extends AnalyzerConfigurable with SimilarityConfigurable {
 
-  def apply(indexAnalyzer: String = getOrElseEn(IndexAnalyzerConfigName),
-            queryAnalyzer: String = getOrElseEn(QueryAnalyzerConfigName),
-            similarity: String = getOrElseClassic(),
-            indexAnalyzerPerField: Map[String, String] = Map.empty[String, String],
-            queryAnalyzerPerField: Map[String, String] = Map.empty[String, String])
+  def apply(indexAnalyzer: String,
+            queryAnalyzer: String,
+            similarity: String,
+            indexAnalyzerPerField: Map[String, String],
+            queryAnalyzerPerField: Map[String, String])
   : LuceneRDDParams = {
     new LuceneRDDParams(indexAnalyzer, queryAnalyzer, similarity,
       indexAnalyzerPerField, queryAnalyzerPerField)
+  }
+
+  def apply(): LuceneRDDParams = {
+    new LuceneRDDParams(getOrElseEn(IndexAnalyzerConfigName),
+      getOrElseEn(QueryAnalyzerConfigName),
+      getOrElseClassic(),
+      Map.empty[String, String],
+      Map.empty[String, String])
   }
 }

--- a/src/main/scala/org/zouzias/spark/lucenerdd/partition/LuceneRDDPartition.scala
+++ b/src/main/scala/org/zouzias/spark/lucenerdd/partition/LuceneRDDPartition.scala
@@ -278,15 +278,15 @@ object LuceneRDDPartition {
     */
   def apply[T: ClassTag](iter: Iterator[T],
                          partitionId: Int,
-                         indexAnalyzer: String,
-                         queryAnalyzer: String,
+                         indexAnalyzerName: String,
+                         queryAnalyzerName: String,
                          similarityName: String,
                          indexAnalyzerPerField: Map[String, String] = Map.empty,
                          queryAnalyzerPerField: Map[String, String] = Map.empty)
                         (implicit docConversion: T => Document)
   : LuceneRDDPartition[T] = {
     new LuceneRDDPartition[T](iter, partitionId,
-      indexAnalyzer, queryAnalyzer, similarityName, indexAnalyzerPerField,
+      indexAnalyzerName, queryAnalyzerName, similarityName, indexAnalyzerPerField,
       queryAnalyzerPerField)(docConversion, classTag[T])
   }
 }

--- a/src/main/scala/org/zouzias/spark/lucenerdd/partition/LuceneRDDPartition.scala
+++ b/src/main/scala/org/zouzias/spark/lucenerdd/partition/LuceneRDDPartition.scala
@@ -46,9 +46,10 @@ import scala.collection.mutable.ArrayBuffer
   * @param partitionId Identifier of the RDD partition
   * @param indexAnalyzerName Lucene Analyzer applied during index time
   * @param queryAnalyzerName Lucene Analyzer applied during query time
+  * @param similarityName Lucene Similarity metric (BM25, Tf/idf)
   * @param indexAnalyzerPerField Lucene Analyzer per field (indexing time)
   * @param queryAnalyzerPerField Lucene Analyzer per field (query time)
-  * @param docConversion Convertion from T to a Lucene document
+  * @param docConversion Conversion from T to a Lucene document
   * @param kTag Class tag of type T
   * @tparam T the type associated with each entry in the set.
   */
@@ -269,8 +270,9 @@ object LuceneRDDPartition {
     * @param partitionId Identifier of the RDD partition
     * @param indexAnalyzerName Lucene Analyzer applied during index time
     * @param queryAnalyzerName Lucene Analyzer applied during query time
-    * @param indexAnalyzerPerField Lucene Analyzer per field (indexing time)
-    * @param queryAnalyzerPerField Lucene Analyzer per field (query time)
+    * @param similarityName Lucene Similarity metric (BM25, Tf/idf)
+    * @param indexAnalyzerPerField Lucene Analyzer per field (indexing time), default empty
+    * @param queryAnalyzerPerField Lucene Analyzer per field (query time), default empty
     * @param docConversion Convertion from T to a Lucene document
     * @param kTag Class tag of type T
     * @tparam T the type associated with each entry in the set.

--- a/src/main/scala/org/zouzias/spark/lucenerdd/query/LuceneQueryHelpers.scala
+++ b/src/main/scala/org/zouzias/spark/lucenerdd/query/LuceneQueryHelpers.scala
@@ -19,6 +19,7 @@ package org.zouzias.spark.lucenerdd.query
 import java.io.StringReader
 
 import org.apache.lucene.analysis.Analyzer
+import org.apache.lucene.analysis.miscellaneous.PerFieldAnalyzerWrapper
 import org.apache.lucene.analysis.tokenattributes.CharTermAttribute
 import org.apache.lucene.document.Document
 import org.apache.lucene.facet.{FacetsCollector, FacetsConfig}
@@ -82,11 +83,12 @@ object LuceneQueryHelpers extends Serializable {
    * Parse a Query string
    *
    * @param searchString
-   * @param analyzer
+   * @param queryAnalyzerPerField Lucene query Analyzers per field
    * @return
    */
-  def parseQueryString(searchString: String, analyzer: Analyzer): Query = {
-    val queryParser = new QueryParser(QueryParserDefaultField, analyzer)
+  def parseQueryString(searchString: String, queryAnalyzerPerField: PerFieldAnalyzerWrapper)
+  : Query = {
+    val queryParser = new QueryParser(QueryParserDefaultField, queryAnalyzerPerField)
     queryParser.parse(searchString)
   }
 
@@ -96,15 +98,15 @@ object LuceneQueryHelpers extends Serializable {
    * @param indexSearcher Index searcher
    * @param searchString Lucene search query string
    * @param topK Number of documents to return
-   * @param analyzer Lucene Analyzer
+   * @param queryAnalyzerPerField Lucene Analyzer per field
    * @return
    */
   def searchParser(indexSearcher: IndexSearcher,
                    searchString: String,
                    topK: Int,
-                   analyzer: Analyzer)
+                   queryAnalyzerPerField: PerFieldAnalyzerWrapper)
   : Seq[SparkScoreDoc] = {
-    val q = parseQueryString(searchString, analyzer)
+    val q = parseQueryString(searchString, queryAnalyzerPerField)
     indexSearcher.search(q, topK).scoreDocs.map(SparkScoreDoc(indexSearcher, _))
   }
 

--- a/src/main/scala/org/zouzias/spark/lucenerdd/store/IndexWithTaxonomyWriter.scala
+++ b/src/main/scala/org/zouzias/spark/lucenerdd/store/IndexWithTaxonomyWriter.scala
@@ -17,6 +17,7 @@
 package org.zouzias.spark.lucenerdd.store
 
 import org.apache.lucene.analysis.Analyzer
+import org.apache.lucene.analysis.miscellaneous.PerFieldAnalyzerWrapper
 import org.apache.lucene.facet.taxonomy.directory.DirectoryTaxonomyWriter
 import org.apache.lucene.index.IndexWriterConfig.OpenMode
 import org.apache.lucene.index.{IndexWriter, IndexWriterConfig}
@@ -30,8 +31,10 @@ trait IndexWithTaxonomyWriter extends IndexStorable
 
   protected def indexAnalyzer(): Analyzer
 
+  protected def indexPerFieldAnalyzer(): PerFieldAnalyzerWrapper
+
   protected lazy val indexWriter = new IndexWriter(IndexDir,
-    new IndexWriterConfig(indexAnalyzer())
+    new IndexWriterConfig(indexPerFieldAnalyzer())
       .setOpenMode(OpenMode.CREATE))
 
   protected lazy val taxoWriter = new DirectoryTaxonomyWriter(TaxonomyDir)

--- a/src/test/scala/org/zouzias/spark/lucenerdd/query/LuceneQueryHelpersSpec.scala
+++ b/src/test/scala/org/zouzias/spark/lucenerdd/query/LuceneQueryHelpersSpec.scala
@@ -27,6 +27,7 @@ import org.apache.lucene.search.IndexSearcher
 import org.scalatest.{BeforeAndAfterEach, FlatSpec, Matchers}
 import org.zouzias.spark.lucenerdd.facets.FacetedLuceneRDD
 import org.zouzias.spark.lucenerdd.store.IndexWithTaxonomyWriter
+import scala.collection.JavaConverters._
 
 import scala.io.Source
 
@@ -39,15 +40,16 @@ class LuceneQueryHelpersSpec extends FlatSpec
   val countries = Source.fromFile("src/test/resources/countries.txt").getLines()
     .map(_.toLowerCase()).toSeq
 
-  val indexAnalyzerPerField = Map("")
+  val indexAnalyzerPerField: Map[String, String] = Map("name"
+    -> "org.apache.lucene.en.EnglishAnalyzer")
 
   private val MaxFacetValue: Int = 10
 
   override def indexAnalyzer: Analyzer = getAnalyzer(Some("en"))
 
   override def indexPerFieldAnalyzer(): PerFieldAnalyzerWrapper = {
-    val analyzerPerField: Map[String, Analyzer] = indexAnalyzerPerField.mapValues(x =>
-      getAnalyzer(Some(x)))
+    val analyzerPerField: Map[String, Analyzer] = indexAnalyzerPerField
+      .mapValues(x => getAnalyzer(Some(x)))
     new PerFieldAnalyzerWrapper(indexAnalyzer(), analyzerPerField.asJava)
   }
 

--- a/src/test/scala/org/zouzias/spark/lucenerdd/query/LuceneQueryHelpersSpec.scala
+++ b/src/test/scala/org/zouzias/spark/lucenerdd/query/LuceneQueryHelpersSpec.scala
@@ -17,6 +17,7 @@
 package org.zouzias.spark.lucenerdd.query
 
 import org.apache.lucene.analysis.Analyzer
+import org.apache.lucene.analysis.miscellaneous.PerFieldAnalyzerWrapper
 import org.apache.lucene.document.Field.Store
 import org.apache.lucene.document._
 import org.apache.lucene.facet.FacetField
@@ -38,9 +39,17 @@ class LuceneQueryHelpersSpec extends FlatSpec
   val countries = Source.fromFile("src/test/resources/countries.txt").getLines()
     .map(_.toLowerCase()).toSeq
 
+  val indexAnalyzerPerField = Map("")
+
   private val MaxFacetValue: Int = 10
 
   override def indexAnalyzer: Analyzer = getAnalyzer(Some("en"))
+
+  override def indexPerFieldAnalyzer(): PerFieldAnalyzerWrapper = {
+    val analyzerPerField: Map[String, Analyzer] = indexAnalyzerPerField.mapValues(x =>
+      getAnalyzer(Some(x)))
+    new PerFieldAnalyzerWrapper(indexAnalyzer(), analyzerPerField.asJava)
+  }
 
   countries.zipWithIndex.foreach { case (elem, index) =>
     val doc = convertToDoc(index % MaxFacetValue, elem)
@@ -101,4 +110,5 @@ class LuceneQueryHelpersSpec extends FlatSpec
     topDocs.forall(doc => doc.doc.textField("_1").exists(x =>
       x.toString().toLowerCase().contains(prefix))) should equal(true)
   }
+
 }


### PR DESCRIPTION
* Scalatest update to 3.0.7
* PerField analyzers

Breaking changes:
* Block linkage methods take as argument `LuceneRDDParams` case class