### PR TITLE
LuceneRDDResponseSpec.collect() should work when no results are found…

### DIFF
--- a/src/main/scala/org/zouzias/spark/lucenerdd/response/LuceneRDDResponse.scala
+++ b/src/main/scala/org/zouzias/spark/lucenerdd/response/LuceneRDDResponse.scala
@@ -76,9 +76,13 @@ private[lucenerdd] class LuceneRDDResponse
 
   override def collect(): Array[SparkScoreDoc] = {
     val sz = partitionsRDD.map(_.size).sum().toInt
-    val monoid = new TopKMonoid[SparkScoreDoc](sz)(ordering)
-    partitionsRDD.map(monoid.build(_))
-      .reduce(monoid.plus).items.toArray
+    if (sz > 0) {
+      val monoid = new TopKMonoid[SparkScoreDoc](sz)(ordering)
+      partitionsRDD.map(monoid.build(_))
+        .reduce(monoid.plus).items.toArray
+    } else {
+      Array.empty[SparkScoreDoc]
+    }
   }
 
   /**

--- a/src/test/scala/org/zouzias/spark/lucenerdd/response/LuceneRDDResponseSpec.scala
+++ b/src/test/scala/org/zouzias/spark/lucenerdd/response/LuceneRDDResponseSpec.scala
@@ -90,4 +90,13 @@ class LuceneRDDResponseSpec extends FlatSpec with Matchers
       equal(org.apache.spark.sql.types.FloatType)
     schema.fields(schema.fieldIndex("email")).dataType should equal(StringType)
   }
+
+
+  "LuceneRDDResponseSpec.collect()" should "work when no results are found" in {
+    val array = Array("aaa", "bbb", "ccc", "ddd", "eee")
+    val rdd = sc.parallelize(array)
+    luceneRDD = LuceneRDD(rdd)
+    val result = luceneRDD.query("fff", 10)
+    result.collect().length should be (0)
+  }
 }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.3.7-SNAPSHOT"
+version in ThisBuild := "0.3.6"


### PR DESCRIPTION
This should fix issue #166 